### PR TITLE
environment.conf permissions are incorrect for custom users or groups

### DIFF
--- a/manifests/server/env.pp
+++ b/manifests/server/env.pp
@@ -38,8 +38,8 @@ define puppet::server::env (
     if $manifest or $config_version or $custom_modulepath or $environment_timeout {
       file { "${basedir}/${name}/environment.conf":
         ensure  => file,
-        owner   => 'root',
-        group   => $::puppet::params::root_group,
+        owner   => $owner,
+        group   => $group,
         mode    => '0644',
         content => template('puppet/server/environment.conf.erb'),
       }


### PR DESCRIPTION
When you set puppet::server_environments_group, and or puppet::server_environments_user, envrionments.conf ends up with differing permissions. This can cause spurrious reloads of puppetmaster or puppetserver. This is probably not right if running with git, though git users may not be messing with the user settings.
